### PR TITLE
Tilt and cone

### DIFF
--- a/src/fvOptions/actuatorLineSource/actuatorLineElement/actuatorLineElement.C
+++ b/src/fvOptions/actuatorLineSource/actuatorLineElement/actuatorLineElement.C
@@ -668,11 +668,10 @@ Foam::scalar Foam::fv::actuatorLineElement::normalRefForce()
 Foam::scalar Foam::fv::actuatorLineElement::inflowRefAngle()
 {
     // Calculate inflow velocity angle in degrees (AFTAL Phi)
-    scalar inflowVelAngleRad = acos
-    (
-        (-relativeVelocity_ & chordRefDirection_)
-        / (mag(relativeVelocity_) * mag(chordRefDirection_))
-    );
+    scalar arg =
+      (-relativeVelocity_ & chordRefDirection_)
+      / (mag(relativeVelocity_) * mag(chordRefDirection_));
+    scalar inflowVelAngleRad = acos(sign(arg)*min(Foam::scalar(1), mag(arg)));
     return radToDeg(inflowVelAngleRad);
 }
 
@@ -718,14 +717,18 @@ void Foam::fv::actuatorLineElement::calculateForce
     relativeVelocity_ = inflowVelocity_ - velocity_;
     Re_ = mag(relativeVelocity_)*chordLength_/nu_;
 
+
     // Calculate angle of attack (radians)
-    scalar angleOfAttackRad = asin((planformNormal_ & relativeVelocity_)
-                            / (mag(planformNormal_)
-                            *  mag(relativeVelocity_)));
+    scalar arg =
+        (-planformNormal_ & relativeVelocity_)
+        / (mag(planformNormal_) * mag(relativeVelocity_));
+    scalar angleOfAttackRad = asin(sign(arg)*min(Foam::scalar(1), mag(arg)));
     scalar angleOfAttackUncorrected = radToDeg(angleOfAttackRad);
     relativeVelocityGeom_ = freeStreamVelocity_ - velocity_;
-    angleOfAttackGeom_ = asin((planformNormal_ & relativeVelocityGeom_)
-                       / (mag(planformNormal_)*mag(relativeVelocityGeom_)));
+    scalar argGeom =
+        (-planformNormal_ & relativeVelocityGeom_)
+        / (mag(planformNormal_) * mag(relativeVelocityGeom_));
+    angleOfAttackGeom_ = asin(sign(argGeom)*min(Foam::scalar(1), mag(argGeom)));
     angleOfAttackGeom_ *= 180.0/pi;
 
     // Apply flow curvature correction to angle of attack

--- a/src/fvOptions/axialFlowTurbineALSource/axialFlowTurbineALSource.C
+++ b/src/fvOptions/axialFlowTurbineALSource/axialFlowTurbineALSource.C
@@ -679,18 +679,7 @@ void Foam::fv::axialFlowTurbineALSource::yaw(scalar radians)
             << endl << endl;
     }
 
-    // First, rotate axis
-    rotateVector(axis_, origin_, verticalDirection_, radians);
-
-    forAll(blades_, i)
-    {
-        blades_[i].rotate(origin_, verticalDirection_, radians);
-    }
-
-    if (hasHub_)
-    {
-        hub_->rotate(origin_, verticalDirection_, radians);
-    }
+    rotateBladesAndHub(radians, verticalDirection_);
 }
 
 

--- a/src/fvOptions/axialFlowTurbineALSource/axialFlowTurbineALSource.C
+++ b/src/fvOptions/axialFlowTurbineALSource/axialFlowTurbineALSource.C
@@ -66,6 +66,9 @@ void Foam::fv::axialFlowTurbineALSource::createCoordinateSystem()
     // Calculate initial azimuthal or tangential direction
     azimuthalDirection_ = axis_ ^ verticalDirection_;
     azimuthalDirection_ /= mag(azimuthalDirection_);
+
+    // Axis of rotation for tilting the turbine
+    tiltAxis_ = azimuthalDirection_;
 }
 
 
@@ -77,6 +80,8 @@ void Foam::fv::axialFlowTurbineALSource::createBlades()
     List<List<scalar> > elementData;
     word modelType = "actuatorLineSource";
     List<scalar> frontalAreas(nBlades); // frontal area from each blade
+    scalar coneAngleDegrees = coeffs_.lookupOrDefault("coneAngle", 0.0);
+    scalar coneAngleRadians = degToRad(coneAngleDegrees);
 
     for (int i = 0; i < nBlades_; i++)
     {
@@ -168,6 +173,8 @@ void Foam::fv::axialFlowTurbineALSource::createBlades()
             scalar velAngle = atan2(((chordMount - 0.25)*chordLength), radius);
             rotateVector(initialVelocity, vector::zero, axis_, velAngle);
             initialVelocities[j] = initialVelocity;
+	    // Cone point towards positive axis direction according to the cone angle
+	    rotateVector(point, origin_, azimuthalDirection_, -coneAngleRadians);
             // Rotate point and initial velocity according to azimuth value
             rotateVector(point, origin_, axis_, azimuthRadians);
             rotateVector
@@ -193,6 +200,8 @@ void Foam::fv::axialFlowTurbineALSource::createBlades()
             vector spanDirection = chordDirection ^ planformNormal;
             spanDirection /= mag(spanDirection);
 
+	    // Cone span towards positive axis direction according to the cone angle
+	    rotateVector(spanDirection, vector::zero, azimuthalDirection_, -coneAngleRadians);
             // Rotate span and chord directions according to azimuth
             rotateVector(spanDirection, vector::zero, axis_, azimuthRadians);
             elementGeometry[j][1][0] = spanDirection.x();
@@ -587,9 +596,13 @@ Foam::fv::axialFlowTurbineALSource::axialFlowTurbineALSource
     scalar azimuthalOffset = coeffs_.lookupOrDefault("azimuthalOffset", 0.0);
     rotate(degToRad(azimuthalOffset));
 
+    // Tilt turbine to a static value if specified
+    scalar tiltAngle = coeffs_.lookupOrDefault("tiltAngle", 0.0);
+    rotateBladesAndHub(degToRad(tiltAngle),tiltAxis_);
+    
     // Yaw turbine to a static value if specified
     scalar yawAngle = coeffs_.lookupOrDefault("yawAngle", 0.0);
-    yaw(degToRad(yawAngle));
+    rotateBladesAndHub(degToRad(yawAngle),verticalDirection_);
 
     if (debug)
     {
@@ -628,6 +641,35 @@ void Foam::fv::axialFlowTurbineALSource::rotate(scalar radians)
     }
 }
 
+void Foam::fv::axialFlowTurbineALSource::rotateBladesAndHub(scalar radians, vector axis)
+{
+    if (debug)
+    {
+        Info<< "Rotating " << name_ << " " << radians << " radians"
+            << endl;
+	Info << "Rotation axis vector: (" << axis.x() << ", " << axis.y()
+	     << ", " << axis.z() << ")" << endl << endl;
+
+    }
+
+    // First, rotate axis
+    rotateVector(axis_, origin_, axis, radians);
+
+    // Second, rotate tilt axis
+    rotateVector(tiltAxis_, origin_, axis, radians);
+
+    // Third, rotate the blades
+    forAll(blades_, i)
+    {
+        blades_[i].rotate(origin_, axis, radians);
+    }
+
+    // Fourth, rotate the hub
+    if (hasHub_)
+    {
+        hub_->rotate(origin_, axis, radians);
+    }
+}
 
 void Foam::fv::axialFlowTurbineALSource::yaw(scalar radians)
 {

--- a/src/fvOptions/axialFlowTurbineALSource/axialFlowTurbineALSource.C
+++ b/src/fvOptions/axialFlowTurbineALSource/axialFlowTurbineALSource.C
@@ -485,9 +485,8 @@ void Foam::fv::axialFlowTurbineALSource::calcEndEffects()
             {
                 vector elementVelDir = elementVel / mag(elementVel);
                 scalar relVelOpElementVel = -elementVelDir & relVel;
-                vector rotorPlaneDir = freeStreamDirection_;
+                vector rotorPlaneDir = -axis_;
                 scalar relVelRotorPlane = rotorPlaneDir & relVel;
-                // Note: Does not take yaw into account
                 phi = atan2(relVelRotorPlane, relVelOpElementVel);
             }
             if (debug)

--- a/src/fvOptions/axialFlowTurbineALSource/axialFlowTurbineALSource.C
+++ b/src/fvOptions/axialFlowTurbineALSource/axialFlowTurbineALSource.C
@@ -598,11 +598,11 @@ Foam::fv::axialFlowTurbineALSource::axialFlowTurbineALSource
 
     // Tilt turbine to a static value if specified
     scalar tiltAngle = coeffs_.lookupOrDefault("tiltAngle", 0.0);
-    rotateBladesAndHub(degToRad(tiltAngle),tiltAxis_);
+    tilt(degToRad(tiltAngle));
     
     // Yaw turbine to a static value if specified
     scalar yawAngle = coeffs_.lookupOrDefault("yawAngle", 0.0);
-    rotateBladesAndHub(degToRad(yawAngle),verticalDirection_);
+    yaw(degToRad(yawAngle));
 
     if (debug)
     {
@@ -653,10 +653,10 @@ void Foam::fv::axialFlowTurbineALSource::rotateBladesAndHub(scalar radians, vect
     }
 
     // First, rotate axis
-    rotateVector(axis_, origin_, axis, radians);
+    rotateVector(axis_, vector::zero, axis, radians);
 
     // Second, rotate tilt axis
-    rotateVector(tiltAxis_, origin_, axis, radians);
+    rotateVector(tiltAxis_, vector::zero, axis, radians);
 
     // Third, rotate the blades
     forAll(blades_, i)
@@ -671,12 +671,21 @@ void Foam::fv::axialFlowTurbineALSource::rotateBladesAndHub(scalar radians, vect
     }
 }
 
+void Foam::fv::axialFlowTurbineALSource::tilt(scalar radians)
+{
+    if (debug)
+    {
+        Info<< "Tilting " << name_ << endl;
+    }
+
+    rotateBladesAndHub(radians, tiltAxis_);
+}
+
 void Foam::fv::axialFlowTurbineALSource::yaw(scalar radians)
 {
     if (debug)
     {
-        Info<< "Yawing " << name_ << " " << radians << " radians"
-            << endl << endl;
+        Info<< "Yawing " << name_ << endl;
     }
 
     rotateBladesAndHub(radians, verticalDirection_);

--- a/src/fvOptions/axialFlowTurbineALSource/axialFlowTurbineALSource.H
+++ b/src/fvOptions/axialFlowTurbineALSource/axialFlowTurbineALSource.H
@@ -90,6 +90,9 @@ protected:
         //- Initial azimuthal direction
         vector azimuthalDirection_;
 
+        //- Initial azimuthal direction
+        vector tiltAxis_;
+
         //- Switch to include tower drag in turbine drag coefficient
         bool includeTowerDrag_;
 
@@ -132,6 +135,9 @@ protected:
         //- Rotate the turbine a specified angle about its axis
         virtual void rotate(scalar radians);
 
+        //- Rotate the turbine blades and hub about specified axis
+        void rotateBladesAndHub(scalar radians, vector axis);
+  
         //- Yaw the turbine, i.e., rotate about vertical axis
         void yaw(scalar radians);
 

--- a/src/fvOptions/axialFlowTurbineALSource/axialFlowTurbineALSource.H
+++ b/src/fvOptions/axialFlowTurbineALSource/axialFlowTurbineALSource.H
@@ -137,6 +137,9 @@ protected:
 
         //- Rotate the turbine blades and hub about specified axis
         void rotateBladesAndHub(scalar radians, vector axis);
+
+        //- Tilt the turbine, i.e., rotate about tilt axis
+        void tilt(scalar radians);
   
         //- Yaw the turbine, i.e., rotate about vertical axis
         void yaw(scalar radians);


### PR DESCRIPTION
Added option to tilt and cone `axialFlowTurbinesALSource.C`. Angles *coneAngle* and *tiltAngle* are set inside `fvOptions`, similar to *yawAngle*. 

Added an additional axis to the turbine named *tiltAxis*. It is initially the same as the *azumithalDirection*, but tilts and yaws together with the turbine.

Added a new function `rotateBladesAndHub(scalar radians, vector axis)` which rotates the turbine's axes, blades, and hub around specified rotational axis "`vector axis`" by specified angle "`scalar radians`".

Updated `yaw()` to use the new function `rotateBladesAndHub()`. Added function `tilt()` which uses `rotateBladesAndHub()`.
 
In function `calcEndEffects()`, "`vector rotorPlaneDir = freeStreamDirection_;`" has been changed to "`vector rotorPlaneDir = -axis_;`" to account for yaw and tilt angle of the turbine. For zero degrees tilt and yaw, the configuration reverts to the original formulation.
 
At 90 degrees tilt, or yaw, floating point errors occurred in functions `inrefFlowAngle()` and `calculateForce()` in `actuatorLineElement.C`. The found reason was arguments to `acos()` and `asin()` were not strictly within the range $[-1, 1]$. To handle this, the arguments are clamped to the range $[-1, 1]$ before `acos()` and `asin()` are used.